### PR TITLE
upgrade sveltejs/kit from 2.49.3 to 2.49.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internationalized/date": "^3.10.1",
     "@lucide/svelte": "^0.562.0",
     "@sveltejs/enhanced-img": "^0.9.2",
-    "@sveltejs/kit": "^2.49.3",
+    "@sveltejs/kit": "^2.49.5",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/table-core": "^8.21.3",


### PR DESCRIPTION
Fix [CVE-2026-22775](https://nvd.nist.gov/vuln/detail/CVE-2026-22775), [details](https://svelte.dev/blog/cves-affecting-the-svelte-ecosystem)